### PR TITLE
feat: implement gut command check-and-correct

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,19 @@
+name: Build
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Build package
+        run: uv build

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ Example interactions:
 - "Push my changes to origin"
 - "Create a pull request"
 
+You can also run gut to check and correct your commands:
+
+```bash
+gut-ai --command "git commit 'feat: analytics'" --question "Why is my command failing?"
+```
+
+Or to simply explain them:
+
+```bash
+gut-ai --command "git checkout -b 'feat/analytics'"
+```
+
+> **Note**: You can also use the `-c` and `-q` as abbreviated flags.
+
 ## 🔧 Development Setup
 
 ### Prerequisites
@@ -76,12 +90,20 @@ uvx --from . gut-ai
 
 gut uses an AI-powered workflow built with [llama-index-workflows](https://github.com/run-llama/workflows-py) that follows these steps:
 
+**Gut interface**
+
 1. **Command Analysis**: Analyzes your natural language input to understand intent
 2. **Command Selection**: Chooses between `git` and `gh` based on your requirements
 3. **Parameter Mapping**: Determines the specific subcommands and options needed
 4. **Explanation Generation**: Creates a clear explanation of what the command will do
 5. **Human Validation**: Shows you the command and explanation for approval
 6. **Execution**: Runs the command if approved, or restarts the process with your feedback
+
+**Gut --command and --question**
+
+1. **Command Analysis**: Analyzes your command and question, producing an explanation and a potential fix for it.
+2. **Human Validation**: Shows you the explanation and, if there, the corrected command and waits for approval
+3. **Execution**: Runs the command if approved, or restarts the process with your feedback
 
 The entire experience runs in a beautiful [Rich](https://github.com/Textualize/rich) console interface with structured inputs and outputs using Pydantic models.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gut-ai"
-version = "0.2.0"
+version = "0.3.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/gut/main.py
+++ b/src/gut/main.py
@@ -1,22 +1,68 @@
 import asyncio
+from argparse import ArgumentParser
 
+from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
-from .workflow import GutWorkflow
+from .workflow import GutWorkflow, CommandWorkflow
 from .workflow.events import (
     MessageEvent,
     ProgressEvent,
     CommandExplanationEvent,
     HumanFeedbackEvent,
     ExecutedEvent,
+    CommandMessageEvent,
 )
 
+cs = Console()
 
-async def run_workflow() -> int:
-    wf = GutWorkflow(timeout=600, disable_validation=True)
-    cs = Console()
+
+async def run_commands_workflow(start_event: CommandMessageEvent) -> int:
+    wf = CommandWorkflow(timeout=600, disable_validation=True)
     cs.print(
-        "[bold cyan]>[/bold cyan] Welcome to gut - your assistant for everything related to [code]git[/code] and [code]gh[/code]! Before we start, let me ask you a question: are you ready to trust your guts on git? [Yes/No]"
+        "[bold cyan]>[/bold cyan] Welcome to gut - your assistant for everything related to [code]git[/code] and [code]gh[/code]! I'll start analyzing your command shortly..."
+    )
+    handler = wf.run(start_event=start_event)
+    with cs.status("[bold green]Working on your request...") as status:
+        async for event in handler.stream_events():
+            if isinstance(event, ProgressEvent):
+                cs.log(event.msg)
+                if event.msg.endswith("[yes/feedback]"):
+                    status.stop()
+                    hitl = cs.input("[bold magenta]>[/bold magenta]")
+                    if hitl.strip().lower() == "yes":
+                        handler.ctx.send_event(  # type: ignore[union-attr]
+                            HumanFeedbackEvent(
+                                approved=True,
+                                feedback="",
+                            )
+                        )
+                    else:
+                        handler.ctx.send_event(  # type: ignore[union-attr]
+                            HumanFeedbackEvent(
+                                approved=False,
+                                feedback=hitl,
+                            )
+                        )
+    result: ExecutedEvent = await handler
+    error = "No Errors" if not result.is_error else "yes"
+    output = "No Output Captured" if not result.output else result.output
+    table = Table(show_footer=False)
+    table.title = "Execution Details"
+    table.add_column("Captured Output", justify="center")
+    table.add_column("Errors", justify="center")
+    table.add_row(
+        output,
+        error,
+    )
+    cs.print(table)
+    return 0
+
+
+async def run_gut_workflow() -> int:
+    wf = GutWorkflow(timeout=600, disable_validation=True)
+    cs.print(
+        "[bold cyan]>[/bold cyan] Welcome to gut - your assistant for everything related to [code]git[/code] and [code]gh[/code]! Before we start, let me ask you a question: are you ready to trust your gut on git? [Yes/No]"
     )
     guts = cs.input("[bold magenta]>[/bold magenta]")
     if guts.lower() == "yes":
@@ -68,6 +114,38 @@ async def run_workflow() -> int:
             error,
         )
         cs.print(table)
+
+
+async def run_workflow() -> int:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-c",
+        "--command",
+        type=str,
+        help="Command to be executed",
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
+        "-q",
+        "--question",
+        type=str,
+        help="Question about the command",
+        required=False,
+        default=None,
+    )
+    args = parser.parse_args()
+    if not args.command and not args.question:
+        return await run_gut_workflow()
+    else:
+        try:
+            start_event = CommandMessageEvent(
+                message=args.question, command=args.command
+            )
+            return await run_commands_workflow(start_event=start_event)
+        except ValidationError as e:
+            cs.print(f"[bold red]ERROR:[/bold red]\n{str(e)}")
+            return 1
 
 
 def main():

--- a/src/gut/models.py
+++ b/src/gut/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Literal
+from typing import Literal, Optional
 
 
 class ShellCommand(BaseModel):
@@ -101,4 +101,14 @@ class CommandToExecute(BaseModel):
     )
     explanation: str = Field(
         description="Detailed-but-concise explanation of why is the command being executed."
+    )
+
+
+class CommandAnalysis(BaseModel):
+    explanation: str = Field(
+        description="Explanation of what the command does or should do, and, if needed, why the command should be changed."
+    )
+    corrected_command: Optional[str] = Field(
+        description="Corrected command. Leave the field blank if the command is already corrected",
+        default=None,
     )

--- a/src/gut/workflow/__init__.py
+++ b/src/gut/workflow/__init__.py
@@ -1,3 +1,4 @@
 from .flow import GutWorkflow
+from .commands import CommandWorkflow
 
-__all__ = ["GutWorkflow"]
+__all__ = ["GutWorkflow", "CommandWorkflow"]

--- a/src/gut/workflow/commands.py
+++ b/src/gut/workflow/commands.py
@@ -1,0 +1,93 @@
+import sys
+import os
+from workflows import Workflow, Context, step
+from workflows.resource import Resource
+from llama_index.core.llms import LLM, ChatMessage
+from typing import Annotated, Union, Optional
+from pydantic import BaseModel, Field
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from .events import (
+    CommandMessageEvent,
+    ProgressEvent,
+    AnalyzeCommandEvent,
+    HumanFeedbackEvent,
+    ExecutedEvent,
+)
+from .resources import get_llm, get_shell, get_xml_formatter
+from utils import Shell, XmlFormatter
+from models import CommandAnalysis
+
+
+class CommandAndQuestion(BaseModel):
+    command: str = Field(default_factory=str)
+    question: str = Field(default_factory=str)
+    corrected_command: Optional[str] = Field(default=None, exclude=True)
+
+
+class CommandWorkflow(Workflow):
+    @step
+    async def analyze_command(
+        self,
+        ctx: Context[CommandAndQuestion],
+        ev: CommandMessageEvent,
+        llm: Annotated[LLM, Resource(get_llm)],
+        xml_formatter: Annotated[XmlFormatter, Resource(get_xml_formatter)],
+    ) -> Union[AnalyzeCommandEvent, ExecutedEvent]:
+        sllm = llm.as_structured_llm(CommandAnalysis)
+        state = await ctx.store.get_state()
+        state.command = ev.command
+        if ev.message:
+            state.question = ev.message
+        else:
+            state.question = "Can you help me understand this command better and, if the command is wrong, correct it?"
+        await ctx.store.set_state(state)
+        try:
+            message_content = xml_formatter.to_xml(state)
+        except Exception:
+            message_content = state.model_dump_json(indent=4)
+        messages = [ChatMessage(role="user", content=message_content)]
+        response = await sllm.achat(messages)
+        if response.message.content is not None:
+            return_event = AnalyzeCommandEvent.model_validate_json(
+                response.message.content
+            )
+            pg_msg = f"Explanation: {return_event.explanation}\n"
+            if return_event.corrected_command:
+                state = await ctx.store.get_state()
+                state.corrected_command = return_event.corrected_command
+                await ctx.store.set_state(state)
+                pg_msg += (
+                    f"Proposed Corrected Command: {return_event.corrected_command}\n"
+                )
+                pg_msg += "Do you want to execute the corrected command? [yes/feedback]"
+                pg_ev = ProgressEvent(msg=pg_msg)
+            else:
+                pg_msg += "Do you want to execute your command? [yes/feedback]"
+                pg_ev = ProgressEvent(msg=pg_msg)
+            ctx.write_event_to_stream(pg_ev)
+            return return_event
+        return ExecutedEvent(
+            is_error=True,
+            output="It was impossible to analyze the command you provided",
+        )
+
+    @step
+    async def execute_command(
+        self,
+        ev: HumanFeedbackEvent,
+        ctx: Context[CommandAndQuestion],
+        sh: Annotated[Shell, Resource(get_shell)],
+    ) -> Union[CommandMessageEvent, ExecutedEvent]:
+        state = await ctx.store.get_state()
+        command = state.corrected_command or state.command
+        if ev.approved:
+            out = sh.run(command)
+            return ExecutedEvent(output=out, is_error="An error occurred\n\n:" in out)
+        else:
+            message = f"My first instructions were: {state.question} and you generated: `{command}`. Now I am asking it to re-generate the command with this feedback: {ev.feedback}"
+            ctx.write_event_to_stream(
+                ProgressEvent(msg="Retrying execution based on human feedback")
+            )
+            return CommandMessageEvent(message=message, command=command)

--- a/src/gut/workflow/events.py
+++ b/src/gut/workflow/events.py
@@ -5,7 +5,7 @@ from workflows.events import (
     HumanResponseEvent,
     StopEvent,
 )
-from pydantic import Field, model_validator
+from pydantic import Field, model_validator, field_validator
 from typing import Optional
 from typing_extensions import Self
 
@@ -51,3 +51,19 @@ class ExecutedEvent(StopEvent):
         elif "An error occurred:\n\n" not in self.output and self.is_error:
             self.is_error = False
         return self
+
+
+class CommandMessageEvent(StartEvent):
+    message: Optional[str] = Field(default=None)
+    command: str
+
+    @field_validator("command")
+    def validate_command(cls, field: str) -> str:
+        if not (field.startswith("git ") or field.startswith("gh ")):
+            raise ValueError("The command must be a git or a gh command!")
+        return field
+
+
+class AnalyzeCommandEvent(InputRequiredEvent):
+    explanation: str
+    corrected_command: Optional[str] = Field(default=None)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,13 @@
 import pytest
 from pydantic import ValidationError
 
-from src.gut.models import ShellCommand, GhCommand, GitCommand, CommandToExecute
+from src.gut.models import (
+    ShellCommand,
+    GhCommand,
+    GitCommand,
+    CommandToExecute,
+    CommandAnalysis,
+)
 
 
 def test_shell_command():
@@ -36,3 +42,15 @@ def test_final_command():
     assert cmd.explanation == "This is a commit command."
     with pytest.raises(ValidationError):
         CommandToExecute(command=1, explanation="This is a wrong command.")
+
+
+def test_command_analysis():
+    cmd = CommandAnalysis(explanation="Explanation")
+    assert cmd.explanation == "Explanation"
+    assert cmd.corrected_command is None
+    cmd = CommandAnalysis(
+        explanation="Explanation", corrected_command="git commit -m 'first commit'"
+    )
+    assert cmd.corrected_command == "git commit -m 'first commit'"
+    with pytest.raises(ValidationError):
+        CommandAnalysis(explanation="Explanation", corrected_command=False)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,12 +1,38 @@
-from src.gut.workflow import GutWorkflow
-from src.gut.workflow.events import ExecutedEvent
+import pytest
+
+from pydantic import ValidationError
+from src.gut.workflow import GutWorkflow, CommandWorkflow
+from src.gut.workflow.events import (
+    ExecutedEvent,
+    CommandMessageEvent,
+    AnalyzeCommandEvent,
+)
 from workflows import Workflow
 
 
-def test_workflow_simple() -> None:
+def test_gut_workflow_simple() -> None:
     wf = GutWorkflow(timeout=600)
     assert isinstance(wf, Workflow)
     assert wf._timeout == 600
+
+
+def test_command_workflow_simple() -> None:
+    wf = CommandWorkflow(timeout=600)
+    assert isinstance(wf, Workflow)
+    assert wf._timeout == 600
+
+
+def test_command_message_event() -> None:
+    ev = CommandMessageEvent(message="message", command="git push origin main")
+    assert ev.message == "message"
+    assert ev.command == "git push origin main"
+    with pytest.raises(ValidationError):
+        CommandMessageEvent(message="message", command="echo 'gut is awesome'")
+
+
+def test_analyze_command_event() -> None:
+    ev = AnalyzeCommandEvent(explanation="explanation")
+    assert ev.corrected_command is None
 
 
 def test_executed_event() -> None:


### PR DESCRIPTION
Added a second workflow that allows the user to check and correct their commands - examples:

1. 
```bash
gut-ai --command "git commit 'feat: analytics'" --question "Why is my command failing?"
```

2.
```bash
gut-ai --command "git checkout -b 'feat/analytics'"
```